### PR TITLE
Regenerate cart references for HPP payments

### DIFF
--- a/adyenv6b2ccheckoutaddon/resources/adyenv6b2ccheckoutaddon-spring.xml
+++ b/adyenv6b2ccheckoutaddon/resources/adyenv6b2ccheckoutaddon-spring.xml
@@ -108,6 +108,7 @@
 		<property name="checkoutCustomerStrategy" ref="checkoutCustomerStrategy"/>
 		<property name="modelService" ref="modelService"/>
 		<property name="commonI18NService" ref="commonI18NService"/>
+		<property name="keyGenerator" ref="orderCodeGenerator"/>
 	</bean>
 
 	<alias name="defaultAdyenPaypalFacade" alias="adyenPaypalFacade" />


### PR DESCRIPTION
**Description**
Use different merchant reference for payment requests for APMs so that multiple notifications are not conflicting. 

**Tested scenarios**
Checkout:
- 1st attempt CC failed, 2nd attempt APM authorised
- 1st attempt APM failed, 2nd attempt APM authorised

