### PR TITLE
Boleto missing fields

### DIFF
--- a/adyenv6core/resources/adyenv6core-beans.xml
+++ b/adyenv6core/resources/adyenv6core-beans.xml
@@ -37,6 +37,7 @@
     <bean class="de.hybris.platform.commercefacades.order.data.AbstractOrderData">
         <property name="adyenBoletoUrl" type="java.lang.String"/>
         <property name="adyenBoletoData" type="java.lang.String"/>
+        <property name="adyenBoletoBarCodeReference" type="String" />
         <property name="adyenBoletoExpirationDate" type="java.util.Date"/>
         <property name="adyenBoletoDueDate" type="java.util.Date"/>
         <property name="adyenMultibancoEntity" type="java.lang.String" />
@@ -65,6 +66,7 @@
     <bean class="de.hybris.platform.commercewebservicescommons.dto.order.AbstractOrderWsDTO">
         <property name="adyenBoletoUrl" type="String" />
         <property name="adyenBoletoData" type="String" />
+        <property name="adyenBoletoBarCodeReference" type="String" />
         <property name="adyenBoletoExpirationDate" type="java.util.Date" />
         <property name="adyenBoletoDueDate" type="java.util.Date" />
         <property name="adyenMultibancoEntity" type="String" />

--- a/adyenv6core/resources/adyenv6core-items.xml
+++ b/adyenv6core/resources/adyenv6core-items.xml
@@ -293,6 +293,22 @@
                         </columntype>
                     </persistence>
                 </attribute>
+                <attribute qualifier="adyenBoletoBarCodeReference" type="java.lang.String">
+                    <description>Boleto bar code</description>
+                    <persistence type="property">
+                        <columntype>
+                            <value>HYBRIS.LONG_STRING</value>
+                        </columntype>
+                    </persistence>
+                </attribute>
+                <attribute qualifier="adyenBoletoDueDate" type="java.util.Date">
+                    <description>Boleto due date</description>
+                    <persistence type="property"/>
+                </attribute>
+                <attribute qualifier="adyenBoletoExpirationDate" type="java.util.Date">
+                    <description>Boleto expiration date</description>
+                    <persistence type="property"/>
+                </attribute>
                 <!-- Multibanco-->
                 <attribute qualifier="adyenMultibancoEntity" type="java.lang.String">
                     <description>Multibanco entity</description>

--- a/adyenv6core/src/com/adyen/v6/facades/DefaultAdyenCheckoutFacade.java
+++ b/adyenv6core/src/com/adyen/v6/facades/DefaultAdyenCheckoutFacade.java
@@ -576,6 +576,7 @@ public class DefaultAdyenCheckoutFacade implements AdyenCheckoutFacade {
 
         orderData.setAdyenBoletoUrl(paymentsResponse.getBoletoUrl());
         orderData.setAdyenBoletoData(paymentsResponse.getBoletoData());
+        orderData.setAdyenBoletoBarCodeReference(paymentsResponse.getBoletoBarCodeReference());
         orderData.setAdyenBoletoExpirationDate(paymentsResponse.getBoletoExpirationDate());
         orderData.setAdyenBoletoDueDate(paymentsResponse.getBoletoDueDate());
 

--- a/adyenv6core/src/com/adyen/v6/populator/AbstractOrderPopulator.java
+++ b/adyenv6core/src/com/adyen/v6/populator/AbstractOrderPopulator.java
@@ -49,6 +49,9 @@ public class AbstractOrderPopulator implements Populator<AbstractOrderModel, Abs
 
             //Set boleto url
             target.setAdyenBoletoUrl(paymentInfo.getAdyenBoletoUrl());
+            target.setAdyenBoletoBarCodeReference(paymentInfo.getAdyenBoletoBarCodeReference());
+            target.setAdyenBoletoDueDate(paymentInfo.getAdyenBoletoDueDate());
+            target.setAdyenBoletoExpirationDate(paymentInfo.getAdyenBoletoExpirationDate());
             //Set multibanco
             target.setAdyenMultibancoAmount(paymentInfo.getAdyenMultibancoAmount());
             target.setAdyenMultibancoDeadline(paymentInfo.getAdyenMultibancoDeadline());

--- a/adyenv6core/src/com/adyen/v6/service/DefaultAdyenOrderService.java
+++ b/adyenv6core/src/com/adyen/v6/service/DefaultAdyenOrderService.java
@@ -138,6 +138,9 @@ public class DefaultAdyenOrderService implements AdyenOrderService {
 
         //Boleto data
         paymentInfo.setAdyenBoletoUrl(paymentsResponse.getBoletoUrl());
+        paymentInfo.setAdyenBoletoBarCodeReference(paymentsResponse.getBoletoBarCodeReference());
+        paymentInfo.setAdyenBoletoDueDate(paymentsResponse.getBoletoDueDate());
+        paymentInfo.setAdyenBoletoExpirationDate(paymentsResponse.getBoletoExpirationDate());
 
         //Multibanco data
         paymentInfo.setAdyenMultibancoEntity(paymentsResponse.getMultibancoEntity());


### PR DESCRIPTION
Add on adyenv6core-items.xml the following fields:

- adyenBoletoBarCodeReference
- adyenBoletoDueDate
- adyenBoletoExpirationDate

Add setter to paymentInfo for those three fields receiving the paymentResponse on DefaultAdyenOrderService.java

**Description**
As aligned with contacts below, we're submitting this PR to fix boleto info saving as described in the conversation.
"Adyen Support (suporte@adyen.com)" <suporte@adyen.com>
Andressa Oizumi <andressa.oizumi@adyen.com>
[AMARO]: Issue: The Adyen plugin is not saving some important information returned in a boleto transaction.
- The due date should be saved in PaymentInfo
- The expiration date should be saved in PaymentInfo
- The barcode should be saved in PaymentInfo
[Adyen]: Yes, we are not storing these values because this information is available in Boleto PDF whose link is store in BoletoURL column. If you want to store these fields too, we can update plugin. You may also create a pull request in our Github and we can approve and release it after review.