### PR TITLE
fix cart duplication on 3ds redirection

### DIFF
--- a/adyenv6b2ccheckoutaddon/resources/adyenv6b2ccheckoutaddon-spring.xml
+++ b/adyenv6b2ccheckoutaddon/resources/adyenv6b2ccheckoutaddon-spring.xml
@@ -48,6 +48,9 @@
 
 	<!--To support hasNoPaymentInfo for non credit cards-->
 	<alias name="adyenCheckoutFlowFacade" alias="checkoutFlowFacade"/>
-	<bean id="adyenCheckoutFlowFacade" class="com.adyen.v6.acceleratorfacades.flow.impl.AdyenCheckoutFlowFacade" parent="defaultCheckoutFlowFacade" />
+	<bean id="adyenCheckoutFlowFacade" class="com.adyen.v6.acceleratorfacades.flow.impl.AdyenCheckoutFlowFacade" parent="defaultCheckoutFlowFacade" >
+		<property name="adyenCheckoutFacade" ref="adyenCheckoutFacade"/>
+		<property name="cartConverter" ref="cartConverter"/>
+	</bean>
 
 	</beans>

--- a/adyenv6b2ccheckoutaddon/src/com/adyen/v6/acceleratorfacades/flow/impl/AdyenCheckoutFlowFacade.java
+++ b/adyenv6b2ccheckoutaddon/src/com/adyen/v6/acceleratorfacades/flow/impl/AdyenCheckoutFlowFacade.java
@@ -20,14 +20,34 @@
  */
 package com.adyen.v6.acceleratorfacades.flow.impl;
 
+import com.adyen.v6.facades.AdyenCheckoutFacade;
+import com.adyen.v6.util.TerminalAPIUtil;
 import de.hybris.platform.acceleratorfacades.flow.impl.DefaultCheckoutFlowFacade;
+import de.hybris.platform.cmsfacades.common.service.SearchResultConverter;
 import de.hybris.platform.commercefacades.order.data.CartData;
+import de.hybris.platform.core.model.order.CartModel;
+import de.hybris.platform.order.InvalidCartException;
+import de.hybris.platform.servicelayer.dto.converter.Converter;
+import org.apache.commons.lang3.exception.ExceptionUtils;
+import org.apache.log4j.Logger;
 
 public class AdyenCheckoutFlowFacade extends DefaultCheckoutFlowFacade
 {
+    private static final Logger LOGGER = Logger.getLogger(AdyenCheckoutFlowFacade.class);
+    private AdyenCheckoutFacade adyenCheckoutFacade;
+    private Converter<CartModel, CartData> cartConverter;
+
+
     @Override
     public CartData getCheckoutCart()
     {
+        try {
+           CartModel cartModel =  getAdyenCheckoutFacade().restoreSessionCart();
+           return getCartConverter().convert(cartModel);
+        } catch (InvalidCartException e) {
+            LOGGER.error(ExceptionUtils.getStackTrace(e));
+        }
+
         final CartData cartData = getCartFacade().getSessionCart();
         if (cartData != null)
         {
@@ -38,10 +58,28 @@ public class AdyenCheckoutFlowFacade extends DefaultCheckoutFlowFacade
         return cartData;
     }
 
+
+
     @Override
     public boolean hasNoPaymentInfo()
     {
         final CartData cartData = getCheckoutCart();
         return cartData == null || cartData.getPaymentInfo() == null;
+    }
+
+    public Converter<CartModel, CartData> getCartConverter() {
+        return cartConverter;
+    }
+
+    public void setCartConverter(Converter<CartModel, CartData> cartConverter) {
+        this.cartConverter = cartConverter;
+    }
+
+    public AdyenCheckoutFacade getAdyenCheckoutFacade() {
+        return adyenCheckoutFacade;
+    }
+
+    public void setAdyenCheckoutFacade(AdyenCheckoutFacade adyenCheckoutFacade) {
+        this.adyenCheckoutFacade = adyenCheckoutFacade;
     }
 }

--- a/adyenv6core/src/com/adyen/v6/facades/DefaultAdyenCheckoutFacade.java
+++ b/adyenv6core/src/com/adyen/v6/facades/DefaultAdyenCheckoutFacade.java
@@ -281,11 +281,6 @@ public class DefaultAdyenCheckoutFacade implements AdyenCheckoutFacade {
     public void lockSessionCart() {
         getSessionService().setAttribute(SESSION_LOCKED_CART, cartService.getSessionCart());
         getSessionService().removeAttribute(SESSION_CART_PARAMETER_NAME);
-
-        //Refresh session for registered users
-        if (! getCheckoutCustomerStrategy().isAnonymousCheckout()) {
-            getCartService().getSessionCart();
-        }
     }
 
     @Override


### PR DESCRIPTION
**Description**
To prevent having multiple carts when paying with 3ds, removing the empty cart creation  when redirecting to 3ds pages, and replace it with a restoration when even the user demands the checkout cart. 

**Tested scenarios**
!!!On another integration!!!
- the user's normal checkout and payment.
- the user's normal checkout with 3ds payment.
- the user's stop in 3ds page and open checkout in another tab (cart restored in session and adyen blocked cart removed from the session), if the user goes back to complete the 3ds challenge he will be redirected to cart (with session cart restored nothing lost).

**Fixed issue**:  
when the user opens a 3ds challenge he can open another tab or device and get a new session cart and proceed in the checkout steps again (he can do the same in the new tab and leave it in the 3ds challenge and open another tab with new empty cart), which is causing a user to have multiple abandoned carts (without limit), this issue leads to many problems like stock reservations, cart reminder emails and more.

details:
https://github.com/Adyen/adyen-hybris/issues/167
https://support.adyen.com/hc/en-us/requests/1252273
https://support.adyen.com/hc/en-us/requests/1206894