### PR TITLE
[PW-2935] Handling "RedirectShopper" for 3DS Fallback policy

### DIFF
--- a/adyenv6b2ccheckoutaddon/acceleratoraddon/web/src/com/adyen/v6/controllers/pages/AdyenSummaryCheckoutStepController.java
+++ b/adyenv6b2ccheckoutaddon/acceleratoraddon/web/src/com/adyen/v6/controllers/pages/AdyenSummaryCheckoutStepController.java
@@ -242,10 +242,11 @@ public class AdyenSummaryCheckoutStepController extends AbstractCheckoutStepCont
                 LOGGER.debug("Handling AdyenNonAuthorizedPaymentException. Checking PaymentResponse.");
                 PaymentsResponse paymentsResponse = e.getPaymentsResponse();
                 if (REDIRECTSHOPPER == paymentsResponse.getResultCode()) {
-                    LOGGER.debug("PaymentResponse resultCode is REDIRECTSHOPPER, redirecting shopper to 3DS flow");
                     if (is3DSPaymentMethod(adyenPaymentMethod)) {
+                        LOGGER.debug("PaymentResponse resultCode is REDIRECTSHOPPER, redirecting shopper to 3DS flow");
                         return redirectTo3DSValidation(model, paymentsResponse);
                     }
+                    LOGGER.debug("PaymentResponse resultCode is REDIRECTSHOPPER, redirecting shopper to local payment method page");
                     return REDIRECT_PREFIX + paymentsResponse.getRedirect().getUrl();
                 }
                 if (REFUSED == paymentsResponse.getResultCode()) {

--- a/adyenv6core/src/com/adyen/v6/facades/DefaultAdyenCheckoutFacade.java
+++ b/adyenv6core/src/com/adyen/v6/facades/DefaultAdyenCheckoutFacade.java
@@ -624,7 +624,12 @@ public class DefaultAdyenCheckoutFacade implements AdyenCheckoutFacade {
 
         PaymentsResponse.ResultCodeEnum resultCode = paymentsResponse.getResultCode();
 
-        if (resultCode != PaymentsResponse.ResultCodeEnum.IDENTIFYSHOPPER && resultCode != PaymentsResponse.ResultCodeEnum.CHALLENGESHOPPER) {
+        if(resultCode == PaymentsResponse.ResultCodeEnum.REDIRECTSHOPPER) {
+            //3DS1 fallback, update payment data
+            getSessionService().setAttribute(SESSION_PAYMENT_DATA, paymentsResponse.getPaymentData());
+        }
+        else if (resultCode != PaymentsResponse.ResultCodeEnum.IDENTIFYSHOPPER
+                && resultCode != PaymentsResponse.ResultCodeEnum.CHALLENGESHOPPER) {
             String orderCode = paymentsResponse.getMerchantReference();
             OrderModel orderModel = retrievePendingOrder(orderCode);
             updateOrderPaymentStatusAndInfo(orderModel, paymentsResponse);


### PR DESCRIPTION
**Description**
Handling 3DS fallback flow:  /payments ==> identifyShopper (3DS2 native resultCode) ==> /payments/details ==> redirectShopper (3DS1 resultCode) ==> /payments/details