### PR TITLE
[PW-3513]: Show only one-click enabled cards on payment methods page

### DIFF
--- a/adyenv6core/src/com/adyen/v6/facades/DefaultAdyenCheckoutFacade.java
+++ b/adyenv6core/src/com/adyen/v6/facades/DefaultAdyenCheckoutFacade.java
@@ -875,8 +875,8 @@ public class DefaultAdyenCheckoutFacade implements AdyenCheckoutFacade {
                                                              .collect(Collectors.toList());
 
         if (showRememberDetails()) {
-            //Include stored cards
-            storedPaymentMethodList = response.getStoredPaymentMethods();
+            //Include stored one-click cards
+            storedPaymentMethodList = getStoredOneClickPaymentMethods(response);
             Set<String> recurringDetailReferences = new HashSet<>();
             if (storedPaymentMethodList != null) {
                 recurringDetailReferences = storedPaymentMethodList.stream().map(StoredPaymentMethod::getId).collect(Collectors.toSet());
@@ -966,6 +966,20 @@ public class DefaultAdyenCheckoutFacade implements AdyenCheckoutFacade {
             return true;
         }
         return false;
+    }
+
+    private List<StoredPaymentMethod> getStoredOneClickPaymentMethods(PaymentMethodsResponse response) {
+        List<StoredPaymentMethod> storedPaymentMethodList = null;
+        if (response.getOneClickPaymentMethods() != null && response.getStoredPaymentMethods() != null) {
+            Set<String> oneClickIds = response.getOneClickPaymentMethods().stream()
+                    .map(com.adyen.model.checkout.RecurringDetail::getRecurringDetailReference)
+                    .collect(Collectors.toSet());
+            storedPaymentMethodList = response.getStoredPaymentMethods().stream()
+                    .filter(storedPaymentMethod -> oneClickIds.contains(storedPaymentMethod.getId()))
+                    .collect(Collectors.toList());
+        }
+
+        return storedPaymentMethodList;
     }
 
     @Override


### PR DESCRIPTION
Recurring contract set as ONECLICK_RECURRING or ONECLICK:
- Payment with card and "SAVE FOR MY NEXT PAYMENT" **not checked** -> card not stored as one-click -> card does not appear on next order.
- Payment with card and "SAVE FOR MY NEXT PAYMENT" **checked** -> card stored as one-click -> card appears on next order as stored card.
