### PR TITLE
#236 : add amount and currency for AdyenVoidCommand

### DIFF
--- a/adyenv6core/src/com/adyen/v6/commands/AdyenVoidCommand.java
+++ b/adyenv6core/src/com/adyen/v6/commands/AdyenVoidCommand.java
@@ -52,6 +52,8 @@ public class AdyenVoidCommand implements VoidCommand {
         result.setRequestTime(new Date());
         result.setTransactionStatus(TransactionStatus.ERROR);
         result.setTransactionStatusDetails(TransactionStatusDetails.UNKNOWN_CODE);
+        result.setAmount(request.getTotalAmount());
+        result.setCurrency(request.getCurrency());
 
         String authReference = request.getRequestId();
         String reference = request.getRequestToken();


### PR DESCRIPTION
**Description**
Add amount and currency to the payment transaction entry when a cancel request is processed.

**Tested scenarios**
- request a payment transaction cancellation, for example, in the order-process
- after the Adyen response is processed, a payment transaction entry is created (already implemented)
- the amount and currency in this payment transaction entry is not empty anymore (implemented in this pull request)

**Fixed issue**:  
https://github.com/Adyen/adyen-hybris/issues/236
