### PR TITLE
Adjust check for setting address postal code

### DIFF
--- a/adyenv6core/src/com/adyen/v6/factory/AdyenRequestFactory.java
+++ b/adyenv6core/src/com/adyen/v6/factory/AdyenRequestFactory.java
@@ -616,7 +616,7 @@ public class AdyenRequestFactory {
             address.setHouseNumberOrName(addressData.getLine2());
         }
 
-        if (addressData.getPostalCode() != null && ! address.getPostalCode().isEmpty()) {
+        if (addressData.getPostalCode() != null && ! addressData.getPostalCode().isEmpty()) {
             address.setPostalCode(addressData.getPostalCode());
         }
 


### PR DESCRIPTION
Issue found by a merchant testing a PayPal transaction with a Hong Kong billing address:
https://adyen.zendesk.com/agent/tickets/2164444

Hong Kong is an example of a country that does not require the Postal Code field. No value was being passed to this field, as a result, payment calls were failing as we were receiving billingAddress.postalCode = null.

The if condition is incorrectly comparing the Adyen address object which will contain "NA" by default, rather than the Hybris addressData object for emptiness. 

