### PR TITLE
Fix String comparison bug in refund command

### DIFF
--- a/adyenv6core/src/com/adyen/v6/commands/AdyenFollowOnRefundCommand.java
+++ b/adyenv6core/src/com/adyen/v6/commands/AdyenFollowOnRefundCommand.java
@@ -78,7 +78,7 @@ public class AdyenFollowOnRefundCommand implements FollowOnRefundCommand<FollowO
 
             LOG.debug("Refund response: " + modificationResult.getResponse());
             //change status to ACCEPTED if there is no error
-            if (modificationResult.getResponse() == REFUND_RECEIVED_RESPONSE) {
+            if (modificationResult.getResponse().equals(REFUND_RECEIVED_RESPONSE)) {
                 result.setTransactionStatus(ACCEPTED);
                 result.setTransactionStatusDetails(REVIEW_NEEDED);
             }


### PR DESCRIPTION
**Description**
Change refund command response String comparison to use .equals - without this even refunds that are successful are reported as "ERROR" TransactionStatus.

**Tested scenarios**
Refunded a payment which was successful - the returned RefundResult was reported as "ACCEPTED"

