### PR TITLE
PW-5754 - Fixed PaymentTransactionModels created from notifications of split payments

### DIFF
--- a/adyenv6core/src/com/adyen/v6/service/AdyenTransactionService.java
+++ b/adyenv6core/src/com/adyen/v6/service/AdyenTransactionService.java
@@ -23,11 +23,14 @@ package com.adyen.v6.service;
 import com.adyen.model.checkout.PaymentsResponse;
 import com.adyen.v6.model.NotificationItemModel;
 import de.hybris.platform.core.model.order.AbstractOrderModel;
+import de.hybris.platform.core.model.order.OrderModel;
 import de.hybris.platform.payment.dto.TransactionStatus;
 import de.hybris.platform.payment.dto.TransactionStatusDetails;
 import de.hybris.platform.payment.enums.PaymentTransactionType;
 import de.hybris.platform.payment.model.PaymentTransactionEntryModel;
 import de.hybris.platform.payment.model.PaymentTransactionModel;
+
+import java.math.BigDecimal;
 
 public interface AdyenTransactionService {
     /**
@@ -93,4 +96,9 @@ public interface AdyenTransactionService {
      * Creates a PaymentTransactionModel
      */
     PaymentTransactionModel createPaymentTransactionFromResultCode(AbstractOrderModel abstractOrderModel, String merchantTransactionCode, String pspReference, PaymentsResponse.ResultCodeEnum resultCodeEnum);
+
+    /**
+     * Stores the authorization transactions for an order
+     */
+    PaymentTransactionModel authorizeOrderModel(AbstractOrderModel abstractOrderModel, String merchantTransactionCode, String pspReference, BigDecimal paymentAmount);
 }

--- a/adyenv6core/src/com/adyen/v6/service/DefaultAdyenNotificationService.java
+++ b/adyenv6core/src/com/adyen/v6/service/DefaultAdyenNotificationService.java
@@ -134,9 +134,9 @@ public class DefaultAdyenNotificationService implements AdyenNotificationService
             return null;
         }
 
-        PaymentTransactionModel paymentTransactionModel = null;
+        PaymentTransactionModel paymentTransactionModel;
         if (notificationItemModel.getSuccess()) {
-            paymentTransactionModel = adyenTransactionService.authorizeOrderModel(orderModel, notificationItemModel.getMerchantReference(), notificationItemModel.getPspReference());
+            paymentTransactionModel = adyenTransactionService.authorizeOrderModel(orderModel, notificationItemModel.getMerchantReference(), notificationItemModel.getPspReference(), notificationItemModel.getAmountValue());
         } else {
             paymentTransactionModel = adyenTransactionService.storeFailedAuthorizationFromNotification(notificationItemModel, orderModel);
         }


### PR DESCRIPTION
**Description**
For split payments, two or more AUTHORISATION notifications are received, each with their own PSP reference and with specific amount paid by each respective payment method.
An issue occurred when the notification processor was saving on SAP's database two notifications with the total amount of the order, instead of considering the amount value received on the notification message.
This fix changes this behaviour so the notifications are saved with their specific amount. Also changed order management action to check if the total amount was already authorised.

**Tested scenarios**
- Processing two or more authorisation notifications for the same order.
- Capture, cancel and refund for these cases. No change was needed since they use the PSP reference from the notification to retrieve the transaction from hybris, which we already save separately for each Authorisation.