### PR TITLE
PW-5759 - Change duplication check so delayed events do not impact other event types

### DIFF
--- a/adyenv6core/src/com/adyen/v6/cronjob/AdyenProcessNotificationCronJob.java
+++ b/adyenv6core/src/com/adyen/v6/cronjob/AdyenProcessNotificationCronJob.java
@@ -52,11 +52,11 @@ public class AdyenProcessNotificationCronJob extends AbstractJobPerformable<Cron
         for (final NotificationItemModel notificationItemModel : nonProcessedNotifications) {
             notificationItemModel.setProcessedAt(new Date());
 
-            boolean isDuplicate = notificationItemRepository.notificationProcessed(notificationItemModel.getPspReference(), notificationItemModel.getEventCode(), notificationItemModel.getSuccess());
+            LOG.debug("Processing event " + notificationItemModel.getEventCode() + " for order with code " + notificationItemModel.getMerchantReference());
 
-            LOG.debug("Processing order with code: " + notificationItemModel.getMerchantReference());
-
-            if (isDuplicate) {
+            NotificationItemModel processedNotification = notificationItemRepository.notificationProcessed(notificationItemModel.getPspReference(), notificationItemModel.getEventCode(), notificationItemModel.getSuccess());
+            if (processedNotification != null) {
+                notificationItemModel.setEventDate(processedNotification.getEventDate());
                 LOG.debug("Skipping duplicate notification");
             } else {
                 boolean isOldNotification = notificationItemRepository.isNewerNotificationExists(notificationItemModel.getMerchantReference(),


### PR DESCRIPTION
**Tested scenarios**
Tested AUTHORISATION events with an eventDate after the CAPTURE.
This results in the capture not being skipped, even if the second authorisation arrives before the capture event.

**Example:**
Notifications had this time sequence for eventDate:
AUTHORISATION - 15:18:14
CAPTURE - 15:36:07 (merchant triggered the capture via API)
AUTHORISATION - 15:43:07

But their createdAt date (the date on which they were received by the plugin) had a different order:
AUTHORISATION - 15:18:15
AUTHORISATION - 15:48:46
CAPTURE - 16:15:28
