### PR TITLE
fix applepay : required field 'merchantIdentifier' is null

### DIFF
--- a/adyenv6b2ccheckoutaddon/acceleratoraddon/web/webroot/_ui/responsive/common/js/adyen.checkout.js
+++ b/adyenv6b2ccheckoutaddon/acceleratoraddon/web/webroot/_ui/responsive/common/js/adyen.checkout.js
@@ -414,7 +414,7 @@ var AdyenCheckoutHybris = (function () {
                 countryCode: countryCode,
                 configuration: {
                     merchantName: applePayMerchantName,
-                    merchantIdentifier: applePayMerchantIdentifier
+                    merchantId: applePayMerchantIdentifier
                 },
                 // Button config
                 buttonType: "plain",


### PR DESCRIPTION
**Description**

When testing Applepay we got an error 500 on https://checkoutshopper-test.adyen.com/checkoutshopper/v1/applePay/sessions call.
The problem comes from the initialization of the Adyen ApplePay component where the object 'configuration' has an attribute 'merchantIdentifier' instead of 'merchantId'.
The attribute 'configuration.merchantId' is then used in adyen.js script to provide the merchantIdentifier value to the /applePay/sessions call.

Below we can see the error we got when the attribute 'configuration.merchantIdentifier' is used instead of 'configuration.merchantId' when initializing the Adyen ApplePay component.

![image](https://user-images.githubusercontent.com/65672066/145557254-659748e0-2b44-423b-8d2d-7e780dd2709d.png)

![image](https://user-images.githubusercontent.com/65672066/145557315-f235b6ba-3f96-4dfa-a816-098c4e4eeee0.png)

