### PR TITLE
PE-138 Set card brand as payment method type for dual branded cards.

### DIFF
--- a/adyenv6b2ccheckoutaddon/acceleratoraddon/web/webroot/_ui/responsive/common/js/adyen.checkout.js
+++ b/adyenv6b2ccheckoutaddon/acceleratoraddon/web/webroot/_ui/responsive/common/js/adyen.checkout.js
@@ -183,6 +183,8 @@ var AdyenCheckoutHybris = (function () {
             if ( this.isDebitCard() ) {
                 $( 'input[name="cardBrand"]' ).val( this.convertCardBrand() );
                 $( 'input[name="cardType"]' ).val( this.getCardType() );
+            } else {
+                $( 'input[name="cardBrand"]' ).val(this.selectedCardBrand);
             }
                  $( 'input[name="browserInfo"]' ).val( JSON.stringify( this.card.data.browserInfo ) );
         },

--- a/adyenv6core/src/com/adyen/v6/factory/AdyenRequestFactory.java
+++ b/adyenv6core/src/com/adyen/v6/factory/AdyenRequestFactory.java
@@ -402,6 +402,11 @@ public class AdyenRequestFactory {
             DefaultPaymentMethodDetails paymentMethodDetails = (DefaultPaymentMethodDetails) paymentsRequest.getPaymentMethod();
             paymentMethodDetails.setStoreDetails(true);
         }
+
+        // For Dual branded card set card brand as payment method type
+        if (!StringUtils.isEmpty(cartData.getAdyenCardBrand())) {
+            paymentsRequest.getPaymentMethod().setType(cartData.getAdyenCardBrand());
+        }
     }
 
     private void updatePaymentRequestForDC(PaymentsRequest paymentsRequest, CartData cartData, RecurringContractMode recurringContractMode) {


### PR DESCRIPTION
**Description**
Set card brand value as payment method type for dual branded cards.

**Tested scenarios**
Credit card and one click payments using various cards.
