### PR TITLE
fix GooglePay payment in adyen component

### DIFF
--- a/adyenv6b2ccheckoutaddon/acceleratoraddon/web/webroot/_ui/responsive/common/js/adyen.checkout.js
+++ b/adyenv6b2ccheckoutaddon/acceleratoraddon/web/webroot/_ui/responsive/common/js/adyen.checkout.js
@@ -483,8 +483,8 @@ var AdyenCheckoutHybris = (function () {
                         self.hideSpinner();
                         return false;
                     }
-                    state.showSpinner();
-                    state.makePayment(state.data.paymentMethod, component, state.handleResult, label);
+                    self.showSpinner();
+                    self.makePayment(state.data.paymentMethod, component, self.handleResult, label);
                 },
                 onClick: function(resolve, reject) {
                     if (self.isTermsAccepted(label)) {


### PR DESCRIPTION
**Description**
The GooglePay component doesn't work.
When we try to pay with GooglePay and after accepting to pay from the GooglePay popup, there is an error in the browser console and the payment cannot be processed.

**Tested scenarios**
With the fix, 
- click on the GooglePay button, add your Google information for testing GooglePay
- click on 'Pay' button from the GooglePay popup
- the payment is processed
- we are then redirected to the order confirmation page


