### PR TITLE
OnlineBanking_PL issuer list missing in Accelerator checkout

### DIFF
--- a/adyencheckoutaddonspa/acceleratoraddon/web/webroot/_ui/responsive/common/js/adyen-checkout/src/global.d.ts
+++ b/adyencheckoutaddonspa/acceleratoraddon/web/webroot/_ui/responsive/common/js/adyen-checkout/src/global.d.ts
@@ -1,0 +1,2 @@
+declare module '*.scss';
+declare module '*.css';

--- a/adyencheckoutaddonspa/acceleratoraddon/web/webroot/_ui/responsive/common/js/adyen-checkout/src/global.d.ts
+++ b/adyencheckoutaddonspa/acceleratoraddon/web/webroot/_ui/responsive/common/js/adyen-checkout/src/global.d.ts
@@ -1,2 +1,0 @@
-declare module '*.scss';
-declare module '*.css';

--- a/adyenv6b2ccheckoutaddon/acceleratoraddon/web/webroot/WEB-INF/tags/responsive/checkoutOrderSummary.tag
+++ b/adyenv6b2ccheckoutaddon/acceleratoraddon/web/webroot/WEB-INF/tags/responsive/checkoutOrderSummary.tag
@@ -11,7 +11,7 @@
 <spring:url value="/checkout/multi/termsAndConditions" var="getTermsAndConditionsUrl"/>
 
 <c:set var="componentsWithPayButton"
-       value="[amazonpay],[applepay],[paypal],[paywithgoogle],[googlepay],[pix],[bcmc_mobile],[upi],[paysafecard],[klarna],[klarna_account],[klarna_paynow],[klarna_b2b],[ideal],[trustly],[swish],[twint],[paypo],[paybybank],[paybybank_AIS_DD],[vipps],[mobilepay],[ebanking_FI]"/>
+       value="[amazonpay],[applepay],[paypal],[paywithgoogle],[googlepay],[pix],[bcmc_mobile],[upi],[paysafecard],[klarna],[klarna_account],[klarna_paynow],[klarna_b2b],[ideal],[trustly],[swish],[twint],[paypo],[paybybank],[paybybank_AIS_DD],[vipps],[mobilepay],[ebanking_FI],[onlineBanking_PL]"/>
 <c:set var="componentPaymentMethod" value="[${selectedPaymentMethod}]" />
 
 <%-- Components --%>

--- a/adyenv6b2ccheckoutaddon/acceleratoraddon/web/webroot/WEB-INF/views/responsive/pages/checkout/multi/selectPaymentMethodPage.jsp
+++ b/adyenv6b2ccheckoutaddon/acceleratoraddon/web/webroot/WEB-INF/views/responsive/pages/checkout/multi/selectPaymentMethodPage.jsp
@@ -63,7 +63,7 @@
             </c:if>
 
             <c:if test="${not empty issuerLists['onlineBanking_PL']}">
-            paymentMethodConfigs['createOnlineBankingPL'] = null;
+            paymentMethodConfigs['createOnlineBankingPL'] = ${issuerLists['onlineBanking_PL']};
             </c:if>
 
             <c:if test="${not empty issuerLists['eps']}">
@@ -272,6 +272,13 @@
                                     <adyen:alternativeMethod
                                             brandCode="ideal"
                                             name="iDEAL"
+                                    />
+                                </c:if>
+
+                                <c:if test="${not empty issuerLists['onlineBanking_PL']}">
+                                    <adyen:alternativeMethod
+                                            brandCode="onlineBanking_PL"
+                                            name="Online Banking Poland"
                                     />
                                 </c:if>
 

--- a/adyenv6b2ccheckoutaddon/acceleratoraddon/web/webroot/_ui/responsive/common/js/adyen_component_factory.js
+++ b/adyenv6b2ccheckoutaddon/acceleratoraddon/web/webroot/_ui/responsive/common/js/adyen_component_factory.js
@@ -106,8 +106,12 @@ class PaymentComponentFactory {
 
     }
 
-    createOnlineBankingPL() {
-        new OnlineBankingIN(this.checkout, {onChange: this.handleOnChange}).mount('#adyen_hpp_onlineBanking_PL_container');
+    createOnlineBankingPL(issuers) {
+        this.onlineBankingPLComponent = new AdyenWeb.OnlineBankingPL(this.checkout, {
+            showPayButton: false,
+            issuers: issuers,
+            onChange: this.handleOnChange
+        }).mount('#adyen_hpp_onlineBanking_PL_container');
     }
 
     createEps(epsDetails) {


### PR DESCRIPTION
AD-537 Enabled issuer-specific support for Online Banking Poland (onlineBanking_PL) and updated relevant UI and components for improved payment handling.

**Description**
Customer reported issue where they couldn't make payment with onlineBanking in normal acceleratorStorefront

**Tested scenarios**
Successful payment with onlineBanking.

**Fixed issue**:  AD-537
