### PR TITLE
Missing property in DefaultAdyenCheckoutApiFacade

### DIFF
--- a/adyenv6core/resources/adyenv6core-spring.xml
+++ b/adyenv6core/resources/adyenv6core-spring.xml
@@ -292,6 +292,7 @@
         <property name="configurationService" ref="configurationService"/>
         <property name="adyenPartialPaymentService" ref="adyenPartialPaymentService"/>
         <property name="adyenPartialPaymentOrderRepository" ref="adyenPartialPaymentOrderRepository" />
+        <property name="threeDSAuthorizationService" ref="threeDSAuthorizationService"/>
     </bean>
 
     <alias name="defaultAdyenGiftCardFacade" alias="adyenGiftCardFacade" />


### PR DESCRIPTION

**Description**
AD-538 Added missing property for threeDSAuthorizationService in adyenenv6core-spring.xml

**Tested scenarios**
<!-- Description of tested scenarios -->

**Fixed issue**:  AD-538
