### PR TITLE
AD-540 Adyen Java API library is on v40.0.0 — multiple major versions behind current stable

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ https://github.com/Adyen/adyen-hybris/releases
 This plugin supports SAP Commerce (Hybris) versions 2211-jdk21 with Spring 6.
 
 The plugin is using following adyen libraries and API.
-- [adyen-java-api-library](https://github.com/Adyen/adyen-java-api-library) (v42.0.0)
+- [adyen-java-api-library](https://github.com/Adyen/adyen-java-api-library) (v42.0.1)
 - [adyen-web](https://github.com/Adyen/adyen-web) (v6.5.0)
 - [Adyen Checkout API](https://docs.adyen.com/api-explorer/) (v71)
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ https://github.com/Adyen/adyen-hybris/releases
 This plugin supports SAP Commerce (Hybris) versions 2211-jdk21 with Spring 6.
 
 The plugin is using following adyen libraries and API.
-- [adyen-java-api-library](https://github.com/Adyen/adyen-java-api-library) (v38.3.0)
+- [adyen-java-api-library](https://github.com/Adyen/adyen-java-api-library) (v42.0.0)
 - [adyen-web](https://github.com/Adyen/adyen-web) (v6.5.0)
 - [Adyen Checkout API](https://docs.adyen.com/api-explorer/) (v71)
 

--- a/adyenv6core/external-dependencies.xml
+++ b/adyenv6core/external-dependencies.xml
@@ -27,7 +27,7 @@
 		<dependency>
 			<groupId>com.adyen</groupId>
 			<artifactId>adyen-java-api-library</artifactId>
-			<version>40.0.0</version>
+			<version>42.0.1</version>
 		</dependency>
 		<dependency>
 			<groupId>jakarta.ws.rs</groupId>


### PR DESCRIPTION

**Description**
Bumped up adyen-java-api-library version to 42.0.1.

**Tested scenarios**
Successful checkout in react storefront, spartacus storefront and default accelerator storefront.

**Fixed issue**:  AD-540
